### PR TITLE
Add advanced CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+---
+name: CodeQL
+
+"on":
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "23 17 * * 1"
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## 概要

Dependabot PR で CodeQL が実解析されず `NEUTRAL` になる問題を解消するため、CodeQL を Default setup から明示的な Advanced setup に切り替えます。

## 変更内容

- `main` への push と pull request で CodeQL を実行
- GitHub Actions と JavaScript/TypeScript を並列解析
- 週次実行と手動実行を追加
- CodeQL Action v4 と必要最小限の権限を設定

## 影響範囲

- GitHub Actions のコードスキャン設定のみ
- アプリケーションコード、依存関係、データベースには変更なし
- PR ごとに2件の CodeQL ジョブが追加実行される

## テスト方法

- Ruby YAML parser による構文確認
- `git diff --check`
- このPRで `actions` と `javascript-typescript` の CodeQL ジョブが成功することを確認
